### PR TITLE
Revert commit to move Disclaimer to headers

### DIFF
--- a/lib/mixminion/server/Modules.py
+++ b/lib/mixminion/server/Modules.py
@@ -1104,14 +1104,15 @@ class MailBase:
             if val:
                 header.append(_wrapHeader("%s: %s" % (h, val)))
 
-        # see if we have a disclaimer
-        disclaimer = sec.get("Message")
-        if disclaimer:
-            disclaimer = "Comment: " + disclaimer
-            header.append(_wrapHeader(disclaimer.strip()))
-
         # Blank line between headers and body
         header.append("\n")
+
+        # See if we have a disclaimer
+        disclaimer = sec.get("Message")
+        if disclaimer:
+            header.append("\n".join(textwrap.wrap(disclaimer.strip())))
+            # blank line between disclaimer and body.
+            header.append("\n\n")
 
         self.header = "".join(header)
 


### PR DESCRIPTION
There is a Comments option that puts a message in headers.  There's also
a Message option that appends a disclaimer message to the payload.
Moving the disclaimer to the headers reduces operator flexibility.

NOTE: Prior to this commit, Mixminion is broken due to a missing "\n" between headers and body.  If this commit isn't desirable, an alternative patch will be required.
