### PR TITLE
SMTP delivery updates

### DIFF
--- a/lib/mixminion/server/Modules.py
+++ b/lib/mixminion/server/Modules.py
@@ -1043,6 +1043,7 @@ class MailBase:
         'SubjectLine': ('ALLOW', None, 'Type III Anonymous Message'),
         'X-Abuse': ('ALLOW', None, None),
         'Comments': ('ALLOW', None, None),
+        'Disclaimer': ('ALLOW', None, None),
         'Message': ('ALLOW', None, None),
         'FromTag': ('ALLOW', None, "[Anon]"),
         'ReturnAddress': ('ALLOW', None, None),
@@ -1099,7 +1100,7 @@ class MailBase:
         header = ["X-Anonymous: yes\n"]
 
         # I'm putting this in a list so adding headers will be simple
-        for h in ['X-Abuse', 'Comments']:
+        for h in ['X-Abuse', 'Comments', 'Disclaimer']:
             val = sec.get(h)
             if val:
                 header.append(_wrapHeader("%s: %s" % (h, val)))

--- a/lib/mixminion/server/Modules.py
+++ b/lib/mixminion/server/Modules.py
@@ -17,6 +17,7 @@ import re
 import sys
 import smtplib
 import socket
+import subprocess
 import threading
 import time
 
@@ -1555,11 +1556,18 @@ def sendSMTPMessage(cfgSection, toList, fromAddr, message):
     # FFFF We should leave the connection open if we're going to send many
     # FFFF messages in a row.
     if cfgSection['SendmailCommand'] is not None:
-        cmd, opts = cfgSection['SendmailCommand']
-        command = cmd + (" ".join(opts))
-        f = os.popen(command, 'w')
-        f.write(message)
-        f.close()
+        cmd, args = cfgSection['SendmailCommand']
+        args.insert(0, cmd)
+        LOG.debug("Using Sendmail Command: %s", " ".join(args))
+        p = subprocess.Popen(args,
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        out, err = p.communicate(message)
+        if len(out) > 0:
+            LOG.warn("%s said on stdout: %s", cmd, out)
+        if len(err) > 0:
+            LOG.warn("%s said on stderr: %s", cmd, out)
         res = DELIVER_OK
     else:
         server = cfgSection.get('SMTPServer', 'localhost')


### PR DESCRIPTION
Add a disclaimer field to message headers (need to add this to manpage).
Use Python's subprocess module for pipes to sendmail.  This method supersedes the os.popen method from Pythons of yesteryear.
